### PR TITLE
fix: Prevent throwing upon sending the magic liink

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export class EmailLinkStrategy<User> extends Strategy<
         const magicLink = await this.sendToken(emailAddress, domainUrl)
 
         session.set(this.sessionMagicLinkKey, await this.encrypt(magicLink))
-        throw redirect(options.successRedirect, {
+        return redirect(options.successRedirect, {
           headers: {
             'Set-Cookie': await sessionStorage.commitSession(session),
           },


### PR DESCRIPTION
Hi @pbteja1998 and thank you for pulling this strategy into a new library in no time! I did find a small issue with throwing that redirect there.

### Current workaround

```js
// /app/routes/auth/email-link.tsx
export const action: ActionFunction = ({ request }) => {
  return authenticator.authenticate('email-link', request, {
    successRedirect: '/auth/verify',
    // *Cannot* specify: failureRedirect: '/login',
  });
};
```

- If I specify a success redirect, then (currently) I cannot specify a failureRedirect.
  - With a valid email: The `throw` sends us to the `catch` where [if you don't specify a `failureRedirect`](https://github.com/pbteja1998/remix-auth-email-link/blob/main/src/index.ts#L241-L243), you then get redirected to `successRedirect`. Works but only without a `failureRedirect`.
- **The bug**: If you specify a `failureRedirect`, even if you enter a valid email address, it throws the `successRedirect` which is getting caught and [you get redirected to the `failureRedirect`](https://github.com/pbteja1998/remix-auth-email-link/blob/main/src/index.ts#L260-L262) route even if the email address you entered is valid.

I can see in the README.md example that you have the above logic in `login.tsx` (plus the `LoaderFunction`) along with the login form but as I have multiple ways to login, I have to rely to `successRedirect` which doesn't seem to work by `throwing`.

Hope it makes sense!

Happy New Year!