### PR TITLE
Feat/additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ type EmailLinkStrategyOptions<User> = {
   linkExpirationTime?: number
   /**
    * The key on the session to store any error message.
-   * @default "auth:error"
+   * @default "auth:error" or what was provided to the Authenticator constructor
+   * @see https://github.com/sergiodxa/remix-auth#reading-authentication-errors
    */
   sessionErrorKey?: string
   /**

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ type EmailLinkStrategyOptions<User> = {
    */
   commitOnReturn?: boolean
   /**
-   * Add an extra layer of protection and validate the magic link is valid.
+   * Add an extra layer of protection and validate the magic link is the same magic link in the existing session.
    * @default false
    */
   validateSessionMagicLink?: boolean

--- a/README.md
+++ b/README.md
@@ -270,7 +270,13 @@ auth.use(
 )
 ```
 
-## Options options
+## A note on `authenticate` without a `successRedirect`
+
+As documented in the [advanced usage section of the remix auth docs](https://github.com/sergiodxa/remix-auth#advanced-usage) if you do not pass the `successRedirect` option to the `authenticator.authenticate` method it will return the user data and you are responsible for setting the user data in the session, committing the session, and (likely) including the headers in the redirect. With this strategy if you do not provide the `successRedirect` the `sessionMagicLinkKey` and `sessionEmailKey` will not be unset and you likely want to unset them.
+
+Alternatively, **if you don't use cookie session storage** you can use the `commitOnReturn` option to have the changes to the session (setting the user and unsetting the magic link and email keys) be committed before returning the user data. In this case as the cookie only contains an id if you don't need any other changes to the session you don't need to manually get the session, commit, create headers, or provide them to the redirect.
+
+## Options
 
 The EmailLinkStrategy supports a few more optional configuration options you can set. Here's the whole type with each option commented.
 
@@ -326,6 +332,18 @@ type EmailLinkStrategyOptions<User> = {
    * @default "auth:magicLink"
    */
   sessionMagicLinkKey?: string
+  /**
+   * The key on the session to store the email.
+   * It's unset the same time the sessionMagicLinkKey is.
+   * @default "auth:email"
+   */
+  sessionEmailKey?: string
+  /**
+   * Should the session be commited before returning
+   * the user data  if the `successRedirect` is omitted.
+   * @default false
+   */
+  commitOnReturn?: boolean
   /**
    * Add an extra layer of protection and validate the magic link is valid.
    * @default false

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ As documented in the [advanced usage section of the remix auth docs](https://git
 
 Alternatively, **if you don't use cookie session storage** you can use the `commitOnReturn` option to have the changes to the session (setting the user and unsetting the magic link and email keys) be committed before returning the user data. In this case as the cookie only contains an id if you don't need any other changes to the session you don't need to manually get the session, commit, create headers, or provide them to the redirect.
 
+## Magic Link Error Messages
+
+The following magic link error types exist:
+
+- expired
+  - Thrown when the magic link has expired.
+  - Default - "Magic link expired. Please request a new one."
+- invalid
+  - Thrown when there is an error decrypting the the magic link code, the email address in the payload is not a string, or the link creation date cannot be determined.
+  - Default - "Sign in link invalid. Please request a new one."
+- mismatch
+  - Only relevant if you provide true for `validateSessionMagicLink`. This error is thrown if the magic link is valid but it does not match with the existing link in the session (or the existing session has no magic link).
+  - Default - "You must open the magic link on the same device it was created from for security reasons. Please request a new link."
+
+You can override any of these messages by setting the relevant key in the `errorMessages` option.
+
 ## Options
 
 The EmailLinkStrategy supports a few more optional configuration options you can set. Here's the whole type with each option commented.
@@ -350,5 +366,9 @@ type EmailLinkStrategyOptions<User> = {
    * @default false
    */
   validateSessionMagicLink?: boolean
+  /**
+   * Customize the magic link error messages
+   */
+  errorMessages?: Partial<Record<MagicLinkErrorType, string>>
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,8 @@ export type EmailLinkStrategyOptions<User> = {
    */
   commitOnReturn?: boolean
   /**
-   * Add an extra layer of protection and validate the magic link is valid.
+   * Add an extra layer of protection and validate the magic link is
+   * the same magic link in the existing session.
    * @default false
    */
   validateSessionMagicLink?: boolean
@@ -411,15 +412,10 @@ export class EmailLinkStrategy<User> extends Strategy<
       throw new TypeError('Sign in link invalid. Please request a new one.')
     }
 
-    if (validateSessionMagicLink) {
-      if (!sessionLinkCode) {
-        throw new Error('Sign in link invalid. Please request a new one.')
-      }
-      if (linkCode !== sessionLinkCode) {
-        throw new Error(
-          `You must open the magic link on the same device it was created from for security reasons. Please request a new link.`
-        )
-      }
+    if (validateSessionMagicLink && linkCode !== sessionLinkCode) {
+      throw new Error(
+        `You must open the magic link on the same device it was created from for security reasons. Please request a new link.`
+      )
     }
 
     if (typeof linkCreationDateString !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,8 @@ export class EmailLinkStrategy<User> extends Strategy<
         throw error
       }
       const { message } = error as Error
+      session.unset(this.sessionMagicLinkKey)
+      session.unset(this.sessionEmailKey)
       session.flash(sessionErrorKey, { message })
       const cookie = await sessionStorage.commitSession(session)
       throw redirect(options.failureRedirect, {


### PR DESCRIPTION
- Adds the email to the session and exposes an option to change the key it's stored in. Should resolve #4 as the current way to deal with this likely involved cloning the request and other workarounds. 
- Adds an option to have the session committed when the user data is returned because a `successRedirect` was omitted. Setting this flag can keep from excessive reading and committing of sessions that aren't stored in cookies.   
- Removes a check that caused the device mismatch to never fire. It was first checking if the magic link on the current session existed, then checking if the magic link on the request was the same. 
- The sessionErrorKey was hardcoded to fallback to `auth:error` if one wasn't provided when the strategy was initialized but [you can set the error key in the `Authenticator` constructor](https://github.com/sergiodxa/remix-auth#reading-authentication-errors) and the current setup would force setting the same value in both constructors. This is potentially a breaking change if someone changed the default `sessionErrorKey` and then relied on the `auth:error` key being automatically set as the unique error key for this particular strategy in a multi-strategy setup. 
- Added error message configuration in the options to be able to customize the messages that are shown for the different error cases. I left all the current error messages as the defaults if no error message overrides are provided. 
- When the verify or validate functions failed the magic link key was not being unset which would cause clicking on expired magic links to still appear as if the session was still in a magic link sent state.
- I removed the `as any` in the check if a thrown value was a redirect to instead check if it's an instance of a Response.
- The readme has been updated to reflect all the changes 