### PR TITLE
docs: improved login action docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ export let action = async ({ request }: ActionArgs) => {
   // The success redirect is required in this action, this is where the user is
   // going to be redirected after the magic link is sent, note that here the
   // user is not yet authenticated, so you can't send it to a private page.
+  const url = new URL(request.url);
   await auth.authenticate('email-link', request, {
-    successRedirect: '/login',
+    successRedirect: url.pathname,
     // If this is not set, any error will be throw and the ErrorBoundary will be
     // rendered.
-    failureRedirect: '/login',
+    failureRedirect: url.pathname,
   })
 }
 


### PR DESCRIPTION
In this PR, I've improved docs, to handle one of the popular edge cases.

Scenario 1:

* User is on /login
* User submits the form and lands in /login route's action handler
* /login route's action handler throws a redirect to */login*
* Result - Remix handles the redirect OK and no infinite redirect loops happen.

**However,**

Scenario 2:

* [given there's a default redirect from / to /en configured]
* User is on /en/login
* User submits the form and lands in /:lang/login route's action handler ($lang.login.tsx)
* /:lang/login route's action handler throws a redirect to */login*
* Result - Remix gets stuck in infinite loop of redirects. The solution here is to use exact same path for the redirect param, to avoid infinite request loops.

So, by improving the docs, I hope ppl will make fewer mistakes in the future.