### PR TITLE
Allow the user to pass formData via the options.context parameter to authenticate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,17 +183,11 @@ export class EmailLinkStrategy<User> extends Strategy<
     sessionStorage: SessionStorage,
     options: AuthenticateOptions
   ): Promise<User> {
+    const formData = await this.resolveFormData(options, request)
+
     const session = await sessionStorage.getSession(
       request.headers.get('Cookie')
     )
-
-    const form = new URLSearchParams(await request.text())
-    const formData = new FormData()
-
-    // Convert the URLSearchParams to FormData
-    for (const [name, value] of form) {
-      formData.append(name, value)
-    }
 
     // This should only be called in an action if it's used to start the login process
     if (request.method === 'POST') {
@@ -204,7 +198,7 @@ export class EmailLinkStrategy<User> extends Strategy<
       }
 
       // get the email address from the request body
-      const emailAddress = form.get(this.emailField)
+      const emailAddress = formData.get(this.emailField)
 
       // if it doesn't have an email address,
       if (!emailAddress || typeof emailAddress !== 'string') {
@@ -450,5 +444,26 @@ export class EmailLinkStrategy<User> extends Strategy<
       }
     })
     return { emailAddress, form: formData }
+  }
+
+  private async resolveFormData(
+    options: AuthenticateOptions,
+    request: Request
+  ): Promise<FormData> {
+    const contextFormData = options.context?.formData
+
+    if (contextFormData instanceof FormData) {
+      return contextFormData
+    } 
+      const form = new URLSearchParams(await request.text())
+      const formData = new FormData()
+
+      // Convert the URLSearchParams to FormData
+      for (const [name, value] of form) {
+        formData.append(name, value)
+      }
+
+      return formData
+    
   }
 }


### PR DESCRIPTION
Hello! 👋 

Thanks for your work on `remix-auth-email-link`. It's a really useful library!

Would you consider accepting a PR like this to allow the user to pass `formData` to `authenticate` the same way `remix-auth-form` does, as described here?

https://remix.run/resources/remix-auth-form-strategy#passing-a-pre-read-formdata-object

This will help me embed a call to authenticate inside an action that can respond to submissions from a couple of different forms.

I see you're doing some interesting stuff to recreate form data from the request, presumably to convert GET requests to POST for when the user click's the magic link. I don't *think* this PR will mess with that (it works for me) but please let me know if you foresee any problems!